### PR TITLE
cmake: use `-static-pie` when applicable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,8 +24,25 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 # link to libc statically
 option(STATIC_LINKING "Link to libc statically" OFF)
 if(STATIC_LINKING)
+    set(STATIC_FLAG "-static")
+
+    # unfortunately, CMAKE_REQUIRED_LINK_OPTIONS was introduced in CMake 3.14
+    # so we have to abuse CMAKE_EXE_LINKER_FLAGS instead.
+    set(CMAKE_EXE_LINKER_FLAGS_BAK "${CMAKE_EXE_LINKER_FLAGS}")
+
+    # check that the compiler supports generation of static PIE executables
+    include(CheckCCompilerFlag)
+    set(CMAKE_EXE_LINKER_FLAGS "-static-pie")
+    check_c_compiler_flag(-static-pie HAVE_STATIC_PIE)
+    if(HAVE_STATIC_PIE)
+        set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+        set(STATIC_FLAG "-static-pie")
+    endif()
+
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS_BAK}")
+
     # libcsexec-loader.so will STILL be linked dynamically
-    set(CMAKE_EXE_LINKER_FLAGS "-static ${CMAKE_EXE_LINKER_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${STATIC_FLAG} ${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 
 # initialize pthreads


### PR DESCRIPTION
... so that we follow Fedora's packaging guidelines and rpminspect will
be happy.