### PR TITLE
tests: fully enable `csexec-argv0` test on glibc 2.34+

### DIFF
--- a/tests/0009-csexec-argv0/test.c
+++ b/tests/0009-csexec-argv0/test.c
@@ -5,10 +5,11 @@
 
 int main(int argc, char **argv)
 {
-    /* ld.so ./executable corrupts auxiliary vector on armv7 and aarch64
-       See https://sourceware.org/bugzilla/show_bug.cgi?id=23293
+    /* ld.so version 2.33 or older corrupts auxiliary vector on armv7
+     * or aarch64.  See https://sourceware.org/bugzilla/show_bug.cgi?id=23293
      */
-#if !__arm__ && !__aarch64__
+#if (!__arm__ && !__aarch64__) || __GLIBC__ > 2 || \
+        (__GLIBC__ == 2 && __GLIBC_MINOR__ > 33)
     const char *at_execfn = (const char *) getauxval(AT_EXECFN);
     assert(strcmp(at_execfn, argv[0]) != 0);
 #endif


### PR DESCRIPTION
The issue with auxiliary vector was fixed in glibc 2.35 and was backported to glibc 2.34.