### PR TITLE
Run `coverity` workflow only on primary repository

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   coverity:
+    if: github.repository == 'csutils/cswrap'
     name: Coverity Scan
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Since `coverity` workflow requires special secrets, it would make sense to disable it for forks.
![Screenshot from 2022-08-09 17-57-56](https://user-images.githubusercontent.com/2879818/183700733-f67a74d1-d803-462a-a519-1982134667a7.png)

