### PR TITLE
cswrap-util: do not wrap nvcc instrumented by cov-build

### DIFF
--- a/src/cswrap-util.c
+++ b/src/cswrap-util.c
@@ -28,6 +28,18 @@
 #include <string.h>
 #include <unistd.h>                 /* for getcwd() */
 
+/* return true if `str` ends with `suffix` */
+static bool endsWith(const char *str, const char *suffix)
+{
+    const size_t len = strlen(str);
+    const size_t suffixLen = strlen(suffix);
+    if (len < suffixLen)
+        return false;
+
+    str += (len - suffixLen);
+    return STREQ(str, suffix);
+}
+
 /* delete the given argument from the argv array */
 void del_arg_from_argv(char **argv)
 {
@@ -177,6 +189,10 @@ bool is_ignored_file(const char *name)
 
     /* used by cov-build on first invocation of CC/CXX */
     if (MATCH_PREFIX(name, "/tmp/cov-mockbuild/"))
+        return true;
+
+    /* used by cov-build while instrumenting nvcc */
+    if (endsWith(name, ".cudafe1.cpp"))
         return true;
 
     /* used by librdkafka-1.6.0 */

--- a/tests/0006-add-del-cflags/runtest.sh
+++ b/tests/0006-add-del-cflags/runtest.sh
@@ -58,3 +58,6 @@ do_check g++ "-Wextra -g -O0 -Wno-extra" "-Wextra -g -O0 -Wno-extra -Wall -Wextr
 
 # preserving flags for conftest.c
 do_check gcc "conftest.c -Werror" "conftest.c -Werror"
+
+# preserving flags for nvcc instrumented by cov-build
+do_check gcc "/tmp/foo_bar.cudafe1.cpp -Werror" "/tmp/foo_bar.cudafe1.cpp -Werror"


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/OSH-692